### PR TITLE
MOD: parse mixin net error

### DIFF
--- a/_examples/multisig/main.go
+++ b/_examples/multisig/main.go
@@ -195,6 +195,16 @@ func main() {
 		if err != nil {
 			log.Panicf("CreateMultisig: %v", err)
 		}
+
+		req, err = subClient.CreateMultisig(ctx, mixin.MultisigActionSign, raw)
+		if err != nil {
+			log.Panicf("CreateMultisig: sign %v", err)
+		}
+
+		req, err = subClient.SignMultisig(ctx, req.RequestID, *pin)
+		if err != nil {
+			log.Panicf("CreateMultisig: %v", err)
+		}
 	}
 	time.Sleep(time.Second * 10)
 }

--- a/error.go
+++ b/error.go
@@ -14,6 +14,10 @@ const (
 	InsufficientFee     = 20124
 	InvalidTraceID      = 20125
 	InvalidReceivers    = 20150
+
+	InvalidOutputKey = 2000001
+	InputLocked      = 2000002
+	InvalidSignature = 2000003
 )
 
 type Error struct {

--- a/mixinnet_transaction.go
+++ b/mixinnet_transaction.go
@@ -26,11 +26,12 @@ type (
 	}
 
 	Transaction struct {
-		Inputs  []*Input  `json:"inputs"`
-		Outputs []*Output `json:"outputs"`
-		Asset   string    `json:"asset"`
-		Extra   string    `json:"extra"`
-		Hash    string    `json:"hash"`
+		Inputs   []*Input  `json:"inputs"`
+		Outputs  []*Output `json:"outputs"`
+		Asset    string    `json:"asset"`
+		Extra    string    `json:"extra"`
+		Hash     string    `json:"hash,omitempty" msgpack:"-"`
+		Snapshot string    `json:"snapshot,omitempty" msgpack:"-"`
 	}
 
 	TransactionInput struct {


### PR DESCRIPTION
1. 如果 SendRawTransaction 返回 InvalidOutputKey 错误，则可能是该 tx 之前已经提交过，直接尝试返回 GetTransaction
2. SendRawTransaction 返回 tx 后未必代表上链成功。还需要看返回的 tx 的 snapshot 是否不为空。如果为空的话需要尝试 GetTransaction ，直至 snapshot 不为空