### PR TITLE
Feature: support Ed25519 keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ demo/demo*
 
 .idea
 .vscode
-/testdata/keystore.json
+/testdata/keystore*.json

--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ func NewFromKeystore(keystore *Keystore) (*Client, error) {
 	return c, nil
 }
 
-// NewFromEd25519Keystore initializes a client with a Ed25519 signer.
+// NewFromEd25519Keystore initializes a client with an Ed25519 signer.
 // You should make sure that the keystore is of Ed25519.
 func NewFromEd25519Keystore(keystore *Keystore) (*Client, error) {
 	auth, err := AuthEd25519FromKeystore(keystore)

--- a/client.go
+++ b/client.go
@@ -28,6 +28,23 @@ func NewFromKeystore(keystore *Keystore) (*Client, error) {
 	return c, nil
 }
 
+// NewFromEd25519Keystore initializes a client with a Ed25519 signer.
+// You should make sure that the keystore is of Ed25519.
+func NewFromEd25519Keystore(keystore *Keystore) (*Client, error) {
+	auth, err := AuthEd25519FromKeystore(keystore)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		Signer:   auth,
+		Verifier: NopVerifier(),
+		ClientID: keystore.ClientID,
+	}
+
+	return c, nil
+}
+
 func NewFromAccessToken(accessToken string) *Client {
 	c := &Client{
 		Signer:   accessTokenAuth(accessToken),

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -39,6 +39,28 @@ func TestKeystoreAuth(t *testing.T) {
 	assert.Equal(t, s.ClientID, me.UserID, "client id should be same")
 }
 
+func TestEd25519KeystoreAuth(t *testing.T) {
+	path := "./testdata/keystore_ed25519.json"
+	f, err := os.Open(path)
+	require.Nil(t, err, "open path: %v", path)
+
+	defer f.Close()
+
+	var store Keystore
+	require.Nil(t, json.NewDecoder(f).Decode(&store), "decode keystore")
+
+	auth, err := AuthEd25519FromKeystore(&store)
+	require.Nil(t, err, "auth from keystore")
+
+	sig := SignRaw("GET", "/me", nil)
+	token := auth.SignToken(sig, newRequestID(), time.Minute)
+
+	me, err := UserMe(context.TODO(), token)
+	require.Nil(t, err, "UserMe")
+
+	assert.Equal(t, store.ClientID, me.UserID, "client id should be same")
+}
+
 func decodePinFromTestData(t *testing.T) string {
 	path := "./testdata/keystore.json"
 	f, err := os.Open(path)

--- a/user_test.go
+++ b/user_test.go
@@ -43,7 +43,7 @@ func TestCreateUser(t *testing.T) {
 	user, keystore, err = botClient.CreateUser(context.TODO(), ed25519PriKey, "name-ed25519")
 	require.NoError(err, "create a user with a Ed25519 key")
 
-	ed25519UserClient, err := NewFromEd25519Keystore(keystore)
+	ed25519UserClient, err := NewFromKeystore(keystore)
 	require.NoError(err, "Ed25519 user client")
 	me, err = ed25519UserClient.UserMe(context.TODO())
 	require.NoError(err, "read the Ed25519 user")

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,53 @@
+package mixin
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUser(t *testing.T) {
+	require := require.New(t)
+
+	path := "./testdata/keystore_bot.json"
+	f, err := os.Open(path)
+	require.NoError(err, "open path: %v", path)
+
+	defer f.Close()
+
+	var store Keystore
+	require.NoError(json.NewDecoder(f).Decode(&store), "decode keystore")
+
+	botClient, err := NewFromKeystore(&store)
+	require.NoError(err, "init bot client")
+
+	// create a user with a RSA key
+	rsaPriKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	user, keystore, err := botClient.CreateUser(context.TODO(), rsaPriKey, "name-rsa")
+	require.NoError(err, "create a user with a RSA key")
+
+	rsaUserClient, err := NewFromKeystore(keystore)
+	require.NoError(err, "RSA user client")
+	me, err := rsaUserClient.UserMe(context.TODO())
+	require.NoError(err, "read the RSA user")
+	require.Equal(me.UserID, user.UserID, "user ids should be same")
+	err = rsaUserClient.ModifyPin(context.TODO(), "", "111111")
+	require.NoError(err, "the RSA user modifies pin")
+
+	ed25519PriKey := GenerateEd25519Key()
+	user, keystore, err = botClient.CreateUser(context.TODO(), ed25519PriKey, "name-ed25519")
+	require.NoError(err, "create a user with a Ed25519 key")
+
+	ed25519UserClient, err := NewFromEd25519Keystore(keystore)
+	require.NoError(err, "Ed25519 user client")
+	me, err = ed25519UserClient.UserMe(context.TODO())
+	require.NoError(err, "read the Ed25519 user")
+	require.Equal(me.UserID, user.UserID, "user ids should be same")
+	err = ed25519UserClient.ModifyPin(context.TODO(), "", "222222")
+	require.NoError(err, "the Ed25519 user modifies pin")
+}


### PR DESCRIPTION
Enable a client to:
1. use an Ed25519 private key as its signer 
2. create network users that have Ed25519 as their private keys