### PR TITLE
support set transport

### DIFF
--- a/request.go
+++ b/request.go
@@ -17,6 +17,7 @@ var (
 	xForceAuthentication = http.CanonicalHeaderKey("x-force-authentication")
 
 	ErrResponseVerifyFailed = errors.New("response verify failed")
+	defaultTransport        = http.DefaultTransport
 )
 
 var httpClient = resty.New().
@@ -56,6 +57,14 @@ var httpClient = resty.New().
 
 		return nil
 	})
+
+func SetTransport(t http.RoundTripper) {
+	httpClient.SetTransport(t)
+}
+
+func UnsetTransport() {
+	httpClient.SetTransport(defaultTransport)
+}
 
 func GetClient() *http.Client {
 	return httpClient.GetClient()


### PR DESCRIPTION
this change allows set and unset proxy(http, https, socks5) for httpClient

example: https://github.com/go-resty/resty/blob/d01e8d1bac5ba1fed0d9e03c4c47ca21e94a7e8e/example_test.go#L221