### PR TITLE
fix: connection close twice

### DIFF
--- a/blaze.go
+++ b/blaze.go
@@ -201,8 +201,6 @@ func connectMixinBlaze(s Signer, opts ...BlazeOption) (*websocket.Conn, error) {
 }
 
 func tick(ctx context.Context, conn *websocket.Conn) error {
-	defer conn.Close()
-
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
I found `LoopBlaze`(the caller of `tick`) also has `defer conn.Close()`, it seems unnecessary here.