### PR TITLE
add api /search/{q} to query user by mixin ID or phone number

### DIFF
--- a/user.go
+++ b/user.go
@@ -85,9 +85,15 @@ func (c *Client) ReadFriends(ctx context.Context) ([]*User, error) {
 	return users, nil
 }
 
-// deprecated. Use ReadUser() instead
-func (c *Client) SearchUser(ctx context.Context, identityNumber string) (*User, error) {
-	return c.ReadUser(ctx, identityNumber)
+func (c *Client) SearchUser(ctx context.Context, identityNumberOrPhoneNumber string) (*User, error) {
+	uri := fmt.Sprintf("/search/%s", identityNumberOrPhoneNumber)
+
+	var user User
+	if err := c.Get(ctx, uri, nil, &user); err != nil {
+		return nil, err
+	}
+
+	return &user, nil
 }
 
 func (c *Client) CreateUser(ctx context.Context, key crypto.Signer, fullname string) (*User, *Keystore, error) {


### PR DESCRIPTION
Related to https://github.com/fox-one/mixin-sdk-go/issues/76, feel free to close this PR if you want to keep this deprecated `SearchUser` API