### PR TITLE
Add AuthorizeToken2 API and mark AuthorizeToken as deprecated

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -6,12 +6,16 @@ import (
 	"time"
 )
 
+func AuthorizeToken2(ctx context.Context, clientID, clientSecret string, code string) (string, string, error) {
+	return AuthorizeToken(ctx, clientID, clientSecret, code, "")
+}
+
+// Deprecated: Use AuthorizeToken2 instead.
 func AuthorizeToken(ctx context.Context, clientID, clientSecret string, code string, verifier string) (string, string, error) {
 	params := map[string]interface{}{
 		"client_id":     clientID,
 		"client_secret": clientSecret,
 		"code":          code,
-		"code_verifier": verifier,
 	}
 
 	resp, err := Request(ctx).SetBody(params).Post("/oauth/token")


### PR DESCRIPTION
According to the document (https://developers.mixin.one/docs/api/oauth/oauth#get-access-token) , there is no request param named `code_verifier`, and this may confuse users. I just add a new API `AuthorizeToken2` to remove the useless param and mark `AuthorizeToken` as deprecated.