### PR TITLE
feat(auth): sign token with custom iat

### DIFF
--- a/keystore.go
+++ b/keystore.go
@@ -111,12 +111,12 @@ func AuthEd25519FromKeystore(store *Keystore) (*KeystoreAuth, error) {
 	return auth, nil
 }
 
-func (k *KeystoreAuth) SignToken(signature, requestID string, exp time.Duration) string {
+func (k *KeystoreAuth) SignTokenAt(signature, requestID string, at time.Time, exp time.Duration) string {
 	jwtMap := jwt.MapClaims{
 		"uid": k.ClientID,
 		"sid": k.SessionID,
-		"iat": time.Now().Unix(),
-		"exp": time.Now().Add(exp).Unix(),
+		"iat": at.Unix(),
+		"exp": at.Add(exp).Unix(),
 		"jti": requestID,
 		"sig": signature,
 		"scp": ScopeFull,
@@ -132,6 +132,10 @@ func (k *KeystoreAuth) SignToken(signature, requestID string, exp time.Duration)
 	}
 
 	return token
+}
+
+func (k *KeystoreAuth) SignToken(signature, requestID string, exp time.Duration) string {
+	return k.SignTokenAt(signature, requestID, time.Now(), exp)
 }
 
 func (k *KeystoreAuth) sequence() uint64 {

--- a/oauth_ed25519.go
+++ b/oauth_ed25519.go
@@ -75,13 +75,13 @@ func AuthFromOauthKeystore(store *OauthKeystore) (*OauthKeystoreAuth, error) {
 	return auth, nil
 }
 
-func (o *OauthKeystoreAuth) SignToken(signature, requestID string, exp time.Duration) string {
+func (o *OauthKeystoreAuth) SignTokenAt(signature, requestID string, at time.Time, exp time.Duration) string {
 	jwtMap := jwt.MapClaims{
 		"iss": o.ClientID,
 		"aid": o.AuthID,
 		"scp": o.Scope,
-		"iat": time.Now().Unix(),
-		"exp": time.Now().Add(exp).Unix(),
+		"iat": at.Unix(),
+		"exp": at.Add(exp).Unix(),
 		"sig": signature,
 		"jti": requestID,
 	}
@@ -92,6 +92,10 @@ func (o *OauthKeystoreAuth) SignToken(signature, requestID string, exp time.Dura
 	}
 
 	return token
+}
+
+func (o *OauthKeystoreAuth) SignToken(signature, requestID string, exp time.Duration) string {
+	return o.SignTokenAt(signature, requestID, time.Now(), exp)
 }
 
 func (o *OauthKeystoreAuth) EncryptPin(pin string) string {


### PR DESCRIPTION
需求：根据时间窗口滚动生成 token，token 在窗口内不变。适用于 token 需要在一段时间内重复使用但是又不想设置很长的有效期的情况。