### PR TITLE
fix: PublicViewKey always be the same when public

### DIFF
--- a/mixinnet_address.go
+++ b/mixinnet_address.go
@@ -27,12 +27,14 @@ type (
 func NewMixinnetAddress(rand io.Reader, public ...bool) *MixinnetAddress {
 	var a = MixinnetAddress{
 		PrivateSpendKey: NewKey(rand),
-		PrivateViewKey:  NewKey(rand),
 	}
 
 	if len(public) > 0 && public[0] {
-		a.PrivateViewKey = a.PublicSpendKey.DeterministicHashDerive()
+		a.PrivateViewKey = a.PrivateSpendKey.DeterministicHashDerive()
+	} else {
+		a.PrivateViewKey = NewKey(rand)
 	}
+
 	a.PublicSpendKey = a.PrivateSpendKey.Public()
 	a.PublicViewKey = a.PrivateViewKey.Public()
 

--- a/mixinnet_address.go
+++ b/mixinnet_address.go
@@ -25,19 +25,19 @@ type (
 )
 
 func NewMixinnetAddress(rand io.Reader, public ...bool) *MixinnetAddress {
+	key := NewKey(rand)
 	var a = MixinnetAddress{
-		PrivateSpendKey: NewKey(rand),
+		PrivateSpendKey: key,
+		PublicSpendKey:  key.Public(),
 	}
 
 	if len(public) > 0 && public[0] {
-		a.PrivateViewKey = a.PrivateSpendKey.DeterministicHashDerive()
+		a.PrivateViewKey = a.PublicSpendKey.DeterministicHashDerive()
 	} else {
 		a.PrivateViewKey = NewKey(rand)
 	}
 
-	a.PublicSpendKey = a.PrivateSpendKey.Public()
 	a.PublicViewKey = a.PrivateViewKey.Public()
-
 	return &a
 }
 

--- a/mixinnet_address_test.go
+++ b/mixinnet_address_test.go
@@ -1,0 +1,17 @@
+package mixin
+
+import (
+	"crypto/rand"
+	"testing"
+)
+
+func TestNewPublicMixinnetAddress(t *testing.T) {
+	r := rand.Reader
+
+	a := NewMixinnetAddress(r, true)
+	b := NewMixinnetAddress(r, true)
+
+	if a.PrivateViewKey.String() == b.PrivateViewKey.String() {
+		t.Errorf("same PrivateViewKey generated %v, %v", a.PrivateViewKey, b.PrivateViewKey)
+	}
+}


### PR DESCRIPTION
```golang
func NewMixinnetAddress(rand io.Reader, public ...bool) *MixinnetAddress {
	var a = MixinnetAddress{
		PrivateSpendKey: NewKey(rand),
		PrivateViewKey:  NewKey(rand),
	}

	if len(public) > 0 && public[0] {
		a.PrivateViewKey = a.PublicSpendKey.DeterministicHashDerive()
	}
	a.PublicSpendKey = a.PrivateSpendKey.Public()
	a.PublicViewKey = a.PrivateViewKey.Public()

	return &a
}
```

```PrivateViewKey``` is always generated from a zero ```PublicSpendKey``` if public is on